### PR TITLE
Add Roboto and Source Sans Pro fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
 
     <meta charset="utf-8">
 
+    <script>
+      (function(d) {
+        var config = {
+          kitId: 'gig7sjk',
+          scriptTimeout: 3000,
+          async: true
+        },
+        h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+      })(document);
+    </script>
+
     <script src="//use.typekit.net/jjo6pal.js"></script>
 
     <script>


### PR DESCRIPTION
@vikasrohit I added the Roboto and Source Sans Pro fonts via typekit. This is the same one we are using in topcoder-app-r. I think we'll end up creating a separate index.html file for the nav webpack bundle, but for now this will let us use the fonts.