### PR TITLE
AS#102852633435494, Integrate new NavBar into topcoder-app

### DIFF
--- a/components/Navbar/Navbar.scss
+++ b/components/Navbar/Navbar.scss
@@ -1,4 +1,6 @@
 @import "topcoder/tc-includes";
+// this is to include tc styles in the output library
+@import "topcoder/tc-styles";
 
 $navbar-bg: #FAFAFB;
 $border-color: #CFCFD2;

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,3 @@
-Router   = require './components/Router/Router'
-
 module.exports =
   default: require './components/FileUploader/FileUploaderContainer.cjsx'
   NavBar: require './components/Navbar/Navbar.jsx'


### PR DESCRIPTION
-- Fixes to exclude unwanted styles (e.g. ExampleApp.scss) in the NavBar bundle. These are causing troubles with calling app's styles.
-- Added required tc styles which got excluded after removing unwanted styles