### PR TITLE
\AS#102852633435494, Integrate new NavBar into topcoder-app

### DIFF
--- a/components/Navbar/Navbar.scss
+++ b/components/Navbar/Navbar.scss
@@ -1,4 +1,3 @@
-@import "topcoder/tc-includes";
 // this is to include tc styles in the output library
 @import "topcoder/tc-styles";
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-navbar": "webpack --build --tc --config navbar.webpack.config.coffee; cp index.html dist/"
   },
   "dependencies": {
-    "appirio-styles": "0.0.25",
+    "appirio-styles": "0.0.26",
     "appirio-tech-api-schemas": "^5.0.69",
     "appirio-tech-client-app-layer": "^0.1.3",
     "classnames": "^2.2.3",


### PR DESCRIPTION
-- Fixed version of appirio-styles to avoid the image reference error.
-- Removed reference to tc-includes because tc-styles already has it