### PR TITLE
Github issue#138, Remove console errors

### DIFF
--- a/components/Formsy/TiledRadioGroup.jsx
+++ b/components/Formsy/TiledRadioGroup.jsx
@@ -45,7 +45,7 @@ class TiledRadioGroup extends Component {
         </a>
       )
       return (
-        <span>
+        <span key={ idx }>
         {
           opt.disabled ?
           <Tooltip>


### PR DESCRIPTION
- removed warning for missing key for TiledRadioGroup component