### PR TITLE
fix #1169

### DIFF
--- a/components/InfiniteList/InfiniteList.jsx
+++ b/components/InfiniteList/InfiniteList.jsx
@@ -140,7 +140,10 @@ class InfiniteList extends Component {
   }
 
   onScrollToLoadPoint() {
-    if (this.state.newItemsCount === 0 || this.state.loading || this.state.items.length >= this.props.itemCountTotal) return;
+    if (this.state.newItemsCount === 0
+        || this.state.loading 
+        || this.state.items.length >= this.props.itemCountTotal)
+      return;
 
     this.addBatchIds();
 

--- a/components/InfiniteList/InfiniteList.jsx
+++ b/components/InfiniteList/InfiniteList.jsx
@@ -140,7 +140,7 @@ class InfiniteList extends Component {
   }
 
   onScrollToLoadPoint() {
-    if (this.state.loading || this.state.items.length >= this.props.itemCountTotal) return;
+    if (this.state.newItemsCount === 0 || this.state.loading || this.state.items.length >= this.props.itemCountTotal) return;
 
     this.addBatchIds();
 
@@ -152,6 +152,7 @@ class InfiniteList extends Component {
       currentItems: this.state.items,
       fetchItems: () => this.fetchNewItems(),
       finishCallback: (newItems) => {
+        this.state.newItemsCount = newItems.length ? newItems.length : 0;
         this.props.fetchItemFinishCallback(newItems);
         this.currentPageIndex += 1;
         this.setLoadingStatus(false);


### PR DESCRIPTION
fixed [Issue #1169](https://github.com/appirio-tech/topcoder-app/issues/1169).
Added a check to break the fetch challenges loop when the server responds with an empty page of challenges.