### PR TITLE
Add support for non standard end date format

### DIFF
--- a/components/ChallengeCard/ChallengeCard.jsx
+++ b/components/ChallengeCard/ChallengeCard.jsx
@@ -18,7 +18,10 @@ const ID_LENGTH = 6;
 const { func, object } = React.PropTypes;
 
 // Get the End date of a challenge
-const getEndDate = date => moment(date).format('MMM DD');
+const getEndDate = (date) => {
+  const endDate = date.split(' ')[0]; // Support non-standard date format
+  return moment(endDate).format('MMM DD');
+};
 
 // Convert a number to string with thousands separated by comma
 const numberWithCommas = n => (n ? n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : 0);

--- a/components/ChallengeFilters/ChallengeFiltersExample.jsx
+++ b/components/ChallengeFilters/ChallengeFiltersExample.jsx
@@ -259,7 +259,8 @@ class ChallengeFiltersExample extends React.Component {
           const existing = map[item.challengeId];
           if (existing) existing.communities.add(community);
           else {
-            const endTimestamp = new Date(item.submissionEndDate).getTime();
+            const submissionEndDate = item.submissionEndDate.split(' ')[0]; // Support non-standard date format
+            const endTimestamp = new Date(submissionEndDate).getTime();
             _.defaults(item, {
               communities: new Set([community]),
               platforms: [],


### PR DESCRIPTION
Some of the challenges in V2 API has end dates in non-standard format eg. "2017-04-10 08:02 ET". This was causing various issues like incorrectly marking a challenge as completed and "Invalid Date" in UI. 