### PR TITLE
fix issue for incorrect remaining time for challenges

### DIFF
--- a/components/ChallengeStatus/ChallengeStatus.jsx
+++ b/components/ChallengeStatus/ChallengeStatus.jsx
@@ -75,7 +75,8 @@ function numSubmissionsTipText(number) {
 
 const getStatusPhase = (challenge) => {
   const { currentPhases } = challenge;
-  const currentPhaseName = currentPhases.length > 0 ? currentPhases[currentPhases.length - 1].phaseType : '';
+  const currentPhase = currentPhases.length > 0 ? currentPhases[0] : '';
+  const currentPhaseName = currentPhase ? currentPhase.phaseType : '';
   switch (currentPhaseName) {
     case 'Registration': {
       if (challenge.checkpointSubmissionEndDate && !getTimeLeft(challenge.checkpointSubmissionEndDate, 'Checkpoint').late) {
@@ -103,36 +104,10 @@ const getStatusPhase = (challenge) => {
         currentPhaseEndDate: challenge.submissionEndDate,
       };
     }
-    case 'Review': {
-      if (challenge.checkpointSubmissionEndDate && !getTimeLeft(challenge.checkpointSubmissionEndDate, 'Checkpoint').late) {
-        return {
-          currentPhaseName: 'Checkpoint',
-          currentPhaseEndDate: challenge.checkpointSubmissionEndDate,
-        };
-      }
-
-      return {
-        currentPhaseName: 'Review',
-        currentPhaseEndDate: challenge.submissionEndDate,
-      };
-    }
-    case 'Approval': {
-      if (challenge.checkpointSubmissionEndDate && !getTimeLeft(challenge.checkpointSubmissionEndDate, 'Checkpoint').late) {
-        return {
-          currentPhaseName: 'Checkpoint',
-          currentPhaseEndDate: challenge.checkpointSubmissionEndDate,
-        };
-      }
-
-      return {
-        currentPhaseName: 'Approval',
-        currentPhaseEndDate: challenge.submissionEndDate,
-      };
-    }
     default:
       return {
         currentPhaseName,
-        currentPhaseEndDate: challenge.submissionEndDate,
+        currentPhaseEndDate: currentPhase.scheduledEndTime,
       };
   }
 };


### PR DESCRIPTION
Fixed issue where remaining time was incorrectly calculated for challenges with all current status except Registration and Submission. Earlier it was picking the registrationenddate which is updated to scheduledenddate for currentphase.
This also fix the issue where progress bar was displaying in red for ongoing challenges.