### PR TITLE
[HOTFIX] Fix appearing TextInput component's value next to input

### DIFF
--- a/components/Formsy/TextInput.jsx
+++ b/components/Formsy/TextInput.jsx
@@ -44,7 +44,7 @@ class TextInput extends Component {
   isValidInput() {
     const value = this.props.getValue()
     const hasError = !this.props.isPristine() && !this.props.isValid()
-    return (!this.props.forceErrorMessage && value && !hasError)
+    return (!this.props.forceErrorMessage && !!value && !hasError)
   }
 
   render() {


### PR DESCRIPTION
Fix appearing TextInput component's value next to input

![screen shot 2018-10-04 at 11 25 58 am](https://user-images.githubusercontent.com/146016/46456277-daaa5d80-c7e0-11e8-8d00-208691d73074.png)
