### PR TITLE
Wizard redesign - Checkboxes and radio buttons with optional description and price (without design update)

### DIFF
--- a/components/Formsy/CheckboxGroup.jsx
+++ b/components/Formsy/CheckboxGroup.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import { HOC as hoc } from 'formsy-react'
 import cn from 'classnames'
+import { numberWithCommas } from './format'
 
 class CheckboxGroup extends Component {
 
@@ -21,7 +22,7 @@ class CheckboxGroup extends Component {
   }
 
   render() {
-    const { label, name, options, layout } = this.props
+    const { label, name, options, layout, wrapperClass } = this.props
     const hasError = !this.props.isPristine() && !this.props.isValid()
     const disabled = this.props.isFormDisabled() || this.props.disabled
     const errorMessage = this.props.getErrorMessage() || this.props.validationError
@@ -30,7 +31,7 @@ class CheckboxGroup extends Component {
       const curValue = this.props.getValue() || []
       const checked = curValue.indexOf(cb.value) !== -1
       const disabled = this.props.isFormDisabled() || cb.disabled || this.props.disabled
-      const rClass = cn('checkbox-group-item', { disabled })
+      const rClass = cn('checkbox-group-item', { disabled, selected: checked })
       const id = name+'-opt-'+key
       const setRef = (c) => this['element-' + key] = c
       return (
@@ -48,10 +49,16 @@ class CheckboxGroup extends Component {
             <label htmlFor={id}/>
           </div>
           <label className="tc-checkbox-label" htmlFor={id}>{cb.label}</label>
+          {
+            cb.quoteUp && !checked && <div className="checkbox-option-price"> {`+ $${numberWithCommas(cb.quoteUp)}`} </div>
+          }
+          {
+            cb.description && checked && <div className="checkbox-option-description"> {cb.description} </div>
+          }
         </div>
       )
     }
-    const chkGrpClass = cn('checkbox-group', {
+    const chkGrpClass = cn('checkbox-group', wrapperClass, {
       horizontal: layout === 'horizontal',
       vertical: layout === 'vertical'
     })

--- a/components/Formsy/TiledCheckboxGroup.jsx
+++ b/components/Formsy/TiledCheckboxGroup.jsx
@@ -1,0 +1,137 @@
+'use strict'
+import React, { PropTypes, Component } from 'react'
+import classNames from 'classnames'
+import Tooltip from '../Tooltip/Tooltip'
+import IconUICheckSimple from '../Icons/IconUICheckSimple'
+import { HOC as hoc } from 'formsy-react'
+
+class TiledCheckboxGroup extends Component {
+  constructor(props) {
+    super(props)
+    this.onChange = this.onChange.bind(this)
+    this.getCheckMarkIconActive = this.getCheckMarkIconActive.bind(this)
+    this.state = { curValue: props.getValue() || [] }
+  }
+
+  onChange(value) {
+    const index = this.state.curValue.indexOf(value)
+    if (index > -1) {
+      this.state.curValue.splice(index, 1)
+    } else {
+      this.state.curValue.push(value)
+    }
+    this.props.setValue(this.state.curValue)
+    this.props.onChange(this.props.name, this.state.curValue)
+  }
+
+  getCheckMarkIconActive() {
+    return (this.props.checkMarkActiveIcon ? this.props.checkMarkActiveIcon : (
+      <span className="check-mark">
+      <IconUICheckSimple fill="#fff" width={12} height={12}/>
+    </span>))
+  }
+
+  render() {
+    const { wrapperClass, options, theme, tabable } = this.props
+    const hasError = !this.props.isPristine() && !this.props.isValid()
+    const disabled = this.props.isFormDisabled() || this.props.disabled
+    const errorMessage = this.props.getErrorMessage() || this.props.validationError
+
+    const renderOption = (opt, idx) => {
+      const checked = this.state.curValue.indexOf(opt.value) > -1
+      const itemClassnames = classNames('tiled-group-item', theme, {
+        active: checked
+      }, {
+        disabled: opt.disabled
+      })
+      const handleClick = () => this.onChange(opt.value)
+      const handleFocus = (e) => {
+        e.target.parentNode.classList.add('focused')
+      }
+      const handleBlur = (e) => {
+        e.target.parentNode.classList.remove('focused')
+      }
+      const Icon = opt.icon
+      const setRef = (c) => this['element-' + idx] = c
+      const renderTile = () => (
+        <a onClick={ !disabled && !opt.disabled && handleClick } data-value={opt.value} className={itemClassnames} key={idx} >
+          {
+            !!tabable &&
+            <input
+              ref={setRef}
+              type="checkbox"
+              name={ this.props.name }
+              style={{ position : 'absolute', left : '-9999px'}}
+              onFocus={handleFocus}
+              onChange={this.onChange}
+              onBlur={handleBlur}
+            />
+          }
+          {
+            this.props.showCheckMarkBeforeTitle
+            && (checked
+            ? this.getCheckMarkIconActive()
+            : this.props.checkMarkUnActiveIcon)
+          }
+          <span className="icon">{ opt.icon && <Icon {...opt.iconOptions} />}</span>
+          <span className="title">{opt.title}</span>
+          <small>{opt.desc}</small>
+          {
+            !this.props.showCheckMarkBeforeTitle
+            && (checked
+            ? this.getCheckMarkIconActive()
+            : this.props.checkMarkUnActiveIcon)
+          }
+        </a>
+      )
+      return (
+        <span key={ idx } className="tiled-group-item-container">
+        {
+          opt.disabled && opt.errorMessage ?
+          <Tooltip>
+            <div className="tooltip-target" id={'tooltip-' + idx}>
+              {renderTile()}
+            </div>
+            <div className="tooltip-body">
+              <p>{opt.errorMessage}</p>
+            </div>
+          </Tooltip> :
+          renderTile()
+        }
+        </span>
+      )
+    }
+
+    return (
+      <div className={`${wrapperClass} tiled-group-row`}>
+
+        {this.props.label && (
+          <label className="tc-label">
+          {this.props.label}
+        </label>)}
+        {options.map(renderOption)}
+      { hasError ? (<p className="error-message">{errorMessage}</p>) : null}
+      </div>
+    )
+  }
+}
+TiledCheckboxGroup.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+      desc: PropTypes.string
+      // icon: PropTypes.
+    }).isRequired
+  ).isRequired,
+  checkMarkActiveIcon: PropTypes.node,
+  checkMarkUnActiveIcon: PropTypes.node,
+  showCheckMarkBeforeTitle: PropTypes.bool
+}
+
+TiledCheckboxGroup.defaultProps = {
+  onChange: () => {},
+  showCheckMarkBeforeTitle: false
+}
+
+export default hoc(TiledCheckboxGroup)

--- a/components/Formsy/TiledCheckboxGroup.jsx
+++ b/components/Formsy/TiledCheckboxGroup.jsx
@@ -15,13 +15,15 @@ class TiledCheckboxGroup extends Component {
 
   onChange(value) {
     const index = this.state.curValue.indexOf(value)
+    let newValue = [...this.state.curValue]
     if (index > -1) {
-      this.state.curValue.splice(index, 1)
+      newValue.splice(index, 1)
     } else {
-      this.state.curValue.push(value)
+      newValue.push(value)
     }
-    this.props.setValue(this.state.curValue)
-    this.props.onChange(this.props.name, this.state.curValue)
+    this.setState({ curValue: newValue })
+    this.props.setValue(newValue)
+    this.props.onChange(this.props.name, newValue)
   }
 
   getCheckMarkIconActive() {

--- a/components/Formsy/TiledCheckboxGroup.jsx
+++ b/components/Formsy/TiledCheckboxGroup.jsx
@@ -10,18 +10,17 @@ class TiledCheckboxGroup extends Component {
     super(props)
     this.onChange = this.onChange.bind(this)
     this.getCheckMarkIconActive = this.getCheckMarkIconActive.bind(this)
-    this.state = { curValue: props.getValue() || [] }
   }
 
   onChange(value) {
-    const index = this.state.curValue.indexOf(value)
-    let newValue = [...this.state.curValue]
+    const curValue = this.props.getValue() || []
+    const index = curValue.indexOf(value)
+    let newValue = [...curValue]
     if (index > -1) {
       newValue.splice(index, 1)
     } else {
       newValue.push(value)
     }
-    this.setState({ curValue: newValue })
     this.props.setValue(newValue)
     this.props.onChange(this.props.name, newValue)
   }
@@ -35,12 +34,13 @@ class TiledCheckboxGroup extends Component {
 
   render() {
     const { wrapperClass, options, theme, tabable } = this.props
+    const curValue = this.props.getValue() || []
     const hasError = !this.props.isPristine() && !this.props.isValid()
     const disabled = this.props.isFormDisabled() || this.props.disabled
     const errorMessage = this.props.getErrorMessage() || this.props.validationError
 
     const renderOption = (opt, idx) => {
-      const checked = this.state.curValue.indexOf(opt.value) > -1
+      const checked = curValue.indexOf(opt.value) > -1
       const itemClassnames = classNames('tiled-group-item', theme, {
         active: checked
       }, {

--- a/components/Formsy/format.js
+++ b/components/Formsy/format.js
@@ -1,0 +1,12 @@
+/**
+ * Helper methods to format values
+ */
+
+/**
+ * Fomats number, separating every 3 digits with comma
+ *
+ * @param {Number} number
+ */
+export function numberWithCommas(number) {
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}

--- a/components/Formsy/index.js
+++ b/components/Formsy/index.js
@@ -9,6 +9,7 @@ import CheckboxGroup from './CheckboxGroup'
 import SliderRadioGroup from './SliderRadioGroup'
 import TiledRadioGroup from './TiledRadioGroup'
 import TiledCheckboxInput from './TiledCheckboxInput'
+import TiledCheckboxGroup from './TiledCheckboxGroup'
 
 require('./FormFields.scss')
 
@@ -39,6 +40,7 @@ export default {
     CheckboxGroup,
     SliderRadioGroup,
     TiledRadioGroup,
-    TiledCheckboxInput
+    TiledCheckboxInput,
+    TiledCheckboxGroup
   }
 }

--- a/components/Formsy/index.js
+++ b/components/Formsy/index.js
@@ -8,6 +8,7 @@ import RadioGroup from './RadioGroup'
 import CheckboxGroup from './CheckboxGroup'
 import SliderRadioGroup from './SliderRadioGroup'
 import TiledRadioGroup from './TiledRadioGroup'
+import TiledCheckboxInput from './TiledCheckboxInput'
 
 require('./FormFields.scss')
 
@@ -37,6 +38,7 @@ export default {
     Checkbox,
     CheckboxGroup,
     SliderRadioGroup,
-    TiledRadioGroup
+    TiledRadioGroup,
+    TiledCheckboxInput
   }
 }


### PR DESCRIPTION
winning submission from challenge 30083737 - Topcoder Connect - Wizard redesign - Controls new design

+ fix to format prices with comma

This PR implements a part of form redesign which is now in https://github.com/appirio-tech/connect-app/tree/feature/form-redesign

After this PR is merged, we have to update dependency in connect app branch `feature/form-redesign`, to point back to `appirio-tech/react-components#feature/connectv2` instead of `maxceem/react-components#feature/connectv2-form-redesign`