### PR TITLE
Removed deprecated methods

### DIFF
--- a/components/Dropdown/Dropdown.jsx
+++ b/components/Dropdown/Dropdown.jsx
@@ -1,6 +1,7 @@
 require('./Dropdown.scss')
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import enhanceDropdown from './enhanceDropdown'
 

--- a/components/Dropdown/DropdownExamples.jsx
+++ b/components/Dropdown/DropdownExamples.jsx
@@ -9,7 +9,7 @@ const items = [
   'Applet Arena'
 ]
 
-const DropdownExamples = {
+class DropdownExamples  extends React.Component {
   render() {
     return (
       <section>
@@ -96,4 +96,4 @@ const DropdownExamples = {
   }
 }
 
-module.exports = React.createClass(DropdownExamples)
+module.exports = DropdownExamples

--- a/components/Dropdown/DropdownItem.jsx
+++ b/components/Dropdown/DropdownItem.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import cn from 'classnames'
 
 const DropdownItem = ({item, onItemClick, currentSelection}) => {

--- a/components/ExampleComponent/ExampleComponent.jsx
+++ b/components/ExampleComponent/ExampleComponent.jsx
@@ -1,5 +1,6 @@
 // Use imports over requires (except scss)
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 // Require local scss file

--- a/components/ExampleNav/ExampleNav.jsx
+++ b/components/ExampleNav/ExampleNav.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
 require('./ExampleNavStyle.scss')

--- a/components/FilePicker/FilePicker.jsx
+++ b/components/FilePicker/FilePicker.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import _ from 'lodash'
 import * as filepicker from 'filestack-js'
 

--- a/components/FileUploader/FileUploaderContainer.cjsx
+++ b/components/FileUploader/FileUploaderContainer.cjsx
@@ -6,15 +6,15 @@ React          = require 'react'
 classnames     = require 'classnames'
 FileUploader   = require './FileUploader'
 
-{ createClass, createElement, PropTypes } = React
+{ createElement, PropTypes } = React
 
 mapStateToProps = (state) ->
   { id, assetType, category, loading } = state?.fileUploader
 
   { id, assetType, category, loading }
 
-container =
-  propTypes:
+class FileUploaderContainer extends React.Component
+  @propTypes =
     id          : PropTypes.string.isRequired
     assetType   : PropTypes.string.isRequired
     category    : PropTypes.string.isRequired
@@ -22,6 +22,10 @@ container =
     loading     : PropTypes.bool
     dragAndDrop : PropTypes.bool
     disableClick: PropTypes.bool
+
+  constructor: (props) ->
+    super(props)
+    this.onChange = this.onChange.bind this
 
   onChange: (files) ->
     { dispatch, id, assetType, category } = this.props
@@ -36,5 +40,5 @@ container =
 
     createElement FileUploader, { onChange, loading, dragAndDrop, disableClick }
 
-module.exports = connect(mapStateToProps)(createClass(container))
+module.exports = connect(mapStateToProps)(FileUploaderContainer)
 

--- a/components/FileUploader/FileUploaderContainer.cjsx
+++ b/components/FileUploader/FileUploaderContainer.cjsx
@@ -1,12 +1,13 @@
 'use strict'
 
 React          = require 'react'
+PropTypes      = require 'prop-types'
 { connect }    = require 'react-redux'
 { uploadFile } = require 'appirio-tech-client-app-layer'
 classnames     = require 'classnames'
 FileUploader   = require './FileUploader'
 
-{ createClass, createElement, PropTypes } = React
+{ createClass, createElement } = React
 
 mapStateToProps = (state) ->
   { id, assetType, category, loading } = state?.fileUploader

--- a/components/Formsy/CheckboxGroup.jsx
+++ b/components/Formsy/CheckboxGroup.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { HOC as hoc } from 'formsy-react'
 import cn from 'classnames'
 import { numberWithCommas } from './format'

--- a/components/Formsy/RadioGroup.jsx
+++ b/components/Formsy/RadioGroup.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { HOC as hoc } from 'formsy-react'
 import cn from 'classnames'
 import { find } from "lodash";

--- a/components/Formsy/SliderRadioGroup.jsx
+++ b/components/Formsy/SliderRadioGroup.jsx
@@ -1,6 +1,7 @@
 'use strict'
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import Slider from 'rc-slider'
 import 'rc-slider/assets/index.css'
 import cn from 'classnames'

--- a/components/Formsy/TiledCheckboxGroup.jsx
+++ b/components/Formsy/TiledCheckboxGroup.jsx
@@ -1,5 +1,6 @@
 'use strict'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import Tooltip from '../Tooltip/Tooltip'
 import IconUICheckSimple from '../Icons/IconUICheckSimple'

--- a/components/Formsy/TiledCheckboxInput.jsx
+++ b/components/Formsy/TiledCheckboxInput.jsx
@@ -1,5 +1,6 @@
 'use strict'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import _ from 'lodash'
 import { HOC as hoc } from 'formsy-react'

--- a/components/Formsy/TiledRadioGroup.jsx
+++ b/components/Formsy/TiledRadioGroup.jsx
@@ -1,5 +1,6 @@
 'use strict'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import Tooltip from '../Tooltip/Tooltip'
 import IconUICheckSimple from '../Icons/IconUICheckSimple'

--- a/components/Icons/IconArrowLogOut.jsx
+++ b/components/Icons/IconArrowLogOut.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowLogOut = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconArrowLogOut = (props) => {
 }
 
 IconArrowLogOut.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowLogOut

--- a/components/Icons/IconArrowMinimalDown.jsx
+++ b/components/Icons/IconArrowMinimalDown.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowMinimalDown = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowMinimalDown = (props) => {
 }
 
 IconArrowMinimalDown.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowMinimalDown

--- a/components/Icons/IconArrowMinimalLeft.jsx
+++ b/components/Icons/IconArrowMinimalLeft.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowMinimalLeft = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowMinimalLeft = (props) => {
 }
 
 IconArrowMinimalLeft.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowMinimalLeft

--- a/components/Icons/IconArrowMinimalRight.jsx
+++ b/components/Icons/IconArrowMinimalRight.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowMinimalRight = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowMinimalRight = (props) => {
 }
 
 IconArrowMinimalRight.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowMinimalRight

--- a/components/Icons/IconArrowMinimalUp.jsx
+++ b/components/Icons/IconArrowMinimalUp.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowMinimalUp = (props) => {
   const fill = props.fill || '#62AADC'
@@ -12,10 +13,10 @@ const IconArrowMinimalUp = (props) => {
 }
 
 IconArrowMinimalUp.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowMinimalUp

--- a/components/Icons/IconArrowPriorityHigh.jsx
+++ b/components/Icons/IconArrowPriorityHigh.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowPriorityHigh = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,9 +15,9 @@ const IconArrowPriorityHigh = (props) => {
 }
 
 IconArrowPriorityHigh.propTypes = {
-  fill   : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowPriorityHigh

--- a/components/Icons/IconArrowPriorityLow.jsx
+++ b/components/Icons/IconArrowPriorityLow.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowPriorityLow = (props) => {
   const fill = props.fill || '#62AADC'
@@ -13,9 +14,9 @@ const IconArrowPriorityLow = (props) => {
 }
 
 IconArrowPriorityLow.propTypes = {
-  fill   : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowPriorityLow

--- a/components/Icons/IconArrowSelect.jsx
+++ b/components/Icons/IconArrowSelect.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowSelect = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowSelect = (props) => {
 }
 
 IconArrowSelect.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowSelect

--- a/components/Icons/IconArrowShareIcon.jsx
+++ b/components/Icons/IconArrowShareIcon.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowShareIcon = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconArrowShareIcon = (props) => {
 }
 
 IconArrowShareIcon.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowShareIcon

--- a/components/Icons/IconArrowTailDown.jsx
+++ b/components/Icons/IconArrowTailDown.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowTailDown = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowTailDown = (props) => {
 }
 
 IconArrowTailDown.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowTailDown

--- a/components/Icons/IconArrowTailLeft.jsx
+++ b/components/Icons/IconArrowTailLeft.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrolTailLeft = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrolTailLeft = (props) => {
 }
 
 IconArrolTailLeft.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrolTailLeft

--- a/components/Icons/IconArrowTailRight.jsx
+++ b/components/Icons/IconArrowTailRight.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowTailRight = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowTailRight = (props) => {
 }
 
 IconArrowTailRight.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowTailRight

--- a/components/Icons/IconArrowTailUp.jsx
+++ b/components/Icons/IconArrowTailUp.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconArrowTailUp = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconArrowTailUp = (props) => {
 }
 
 IconArrowTailUp.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconArrowTailUp

--- a/components/Icons/IconDesignCode.jsx
+++ b/components/Icons/IconDesignCode.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconDesignCode = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconDesignCode = (props) => {
 }
 
 IconDesignCode.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconDesignCode

--- a/components/Icons/IconFilesSingleFoldedContent.jsx
+++ b/components/Icons/IconFilesSingleFoldedContent.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconFileSingleFoldedContent = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconFileSingleFoldedContent = (props) => {
 }
 
 IconFileSingleFoldedContent.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconFileSingleFoldedContent

--- a/components/Icons/IconMediaImage.jsx
+++ b/components/Icons/IconMediaImage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconName = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconName = (props) => {
 }
 
 IconName.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconName

--- a/components/Icons/IconTcCarretDown.jsx
+++ b/components/Icons/IconTcCarretDown.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconCarretDown = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,11 +15,11 @@ const IconCarretDown = (props) => {
 }
 
 IconCarretDown.propTypes = {
-  wrapperClass   : React.PropTypes.string,
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  wrapperClass   : PropTypes.string,
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconCarretDown

--- a/components/Icons/IconTcCarretUp.jsx
+++ b/components/Icons/IconTcCarretUp.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconCarretUp = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconCarretUp = (props) => {
 }
 
 IconCarretUp.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconCarretUp

--- a/components/Icons/IconTcMenuBold.jsx
+++ b/components/Icons/IconTcMenuBold.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcMenuBold = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcMenuBold = (props) => {
 }
 
 IconTcMenuBold.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcMenuBold

--- a/components/Icons/IconTcSpecIconTypeColorHome.jsx
+++ b/components/Icons/IconTcSpecIconTypeColorHome.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcSpecIconTypeColorHome = (props) => {
   const height = props.height || '46'
@@ -17,8 +18,8 @@ const IconTcSpecIconTypeColorHome = (props) => {
 }
 
 IconTcSpecIconTypeColorHome.propTypes = {
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcSpecIconTypeColorHome

--- a/components/Icons/IconTcSpecIconTypeGlyphHome.jsx
+++ b/components/Icons/IconTcSpecIconTypeGlyphHome.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcSpecIconTypeGlyphHome = (props) => {
   const fill = props.fill || '#62AADC'
@@ -16,10 +17,10 @@ const IconTcSpecIconTypeGlyphHome = (props) => {
 }
 
 IconTcSpecIconTypeGlyphHome.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcSpecIconTypeGlyphHome

--- a/components/Icons/IconTcSpecIconTypeOutlineHome.jsx
+++ b/components/Icons/IconTcSpecIconTypeOutlineHome.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcSpecIconTypeOutlineHome = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconTcSpecIconTypeOutlineHome = (props) => {
 }
 
 IconTcSpecIconTypeOutlineHome.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcSpecIconTypeOutlineHome

--- a/components/Icons/IconTcSpecTypeSansSerif.jsx
+++ b/components/Icons/IconTcSpecTypeSansSerif.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcSpecTypeSansSerif = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcSpecTypeSansSerif = (props) => {
 }
 
 IconTcSpecTypeSansSerif.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcSpecTypeSansSerif

--- a/components/Icons/IconTcSpecTypeSerif.jsx
+++ b/components/Icons/IconTcSpecTypeSerif.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcSpecTypeSerif = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcSpecTypeSerif = (props) => {
 }
 
 IconTcSpecTypeSerif.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcSpecTypeSerif

--- a/components/Icons/IconTcTextBold.jsx
+++ b/components/Icons/IconTcTextBold.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcTextBold = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcTextBold = (props) => {
 }
 
 IconTcTextBold.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcTextBold

--- a/components/Icons/IconTcTextItalic.jsx
+++ b/components/Icons/IconTcTextItalic.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcTextItalic = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcTextItalic = (props) => {
 }
 
 IconTcTextItalic.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcTextItalic

--- a/components/Icons/IconTcTextUnderline.jsx
+++ b/components/Icons/IconTcTextUnderline.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTcTextUnderline = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTcTextUnderline = (props) => {
 }
 
 IconTcTextUnderline.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTcTextUnderline

--- a/components/Icons/IconTechOutlineDesktop.jsx
+++ b/components/Icons/IconTechOutlineDesktop.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineDesktop = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTechOutlineDesktop = (props) => {
 }
 
 IconTechOutlineDesktop.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineDesktop

--- a/components/Icons/IconTechOutlineMobile.jsx
+++ b/components/Icons/IconTechOutlineMobile.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineMobile = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTechOutlineMobile = (props) => {
 }
 
 IconTechOutlineMobile.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineMobile

--- a/components/Icons/IconTechOutlineTablet.jsx
+++ b/components/Icons/IconTechOutlineTablet.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineTablet = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTechOutlineTablet = (props) => {
 }
 
 IconTechOutlineTablet.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineTablet

--- a/components/Icons/IconTechOutlineWatchAndroid.jsx
+++ b/components/Icons/IconTechOutlineWatchAndroid.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineWatchAndroid = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTechOutlineWatchAndroid = (props) => {
 }
 
 IconTechOutlineWatchAndroid.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineWatchAndroid

--- a/components/Icons/IconTechOutlineWatchApple.jsx
+++ b/components/Icons/IconTechOutlineWatchApple.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineWatchApple = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTechOutlineWatchApple = (props) => {
 }
 
 IconTechOutlineWatchApple.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineWatchApple

--- a/components/Icons/IconTechOutlineWorkProject.jsx
+++ b/components/Icons/IconTechOutlineWorkProject.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTechOutlineWorkProject = (props) => {
   const stroke = props.stroke || '#262628'
@@ -21,9 +22,9 @@ const IconTechOutlineWorkProject = (props) => {
 }
 
 IconTechOutlineWorkProject.propTypes = {
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTechOutlineWorkProject

--- a/components/Icons/IconTextListBullet.jsx
+++ b/components/Icons/IconTextListBullet.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTextListBullet = (props) => {
   const fill = props.fill || '#62AADC'
@@ -17,10 +18,10 @@ const IconTextListBullet = (props) => {
 }
 
 IconTextListBullet.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTextListBullet

--- a/components/Icons/IconTextListNumbers.jsx
+++ b/components/Icons/IconTextListNumbers.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTextListNumbers = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconTextListNumbers = (props) => {
 }
 
 IconTextListNumbers.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTextListNumbers

--- a/components/Icons/IconTextQuote.jsx
+++ b/components/Icons/IconTextQuote.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconTextQuote = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconTextQuote = (props) => {
 }
 
 IconTextQuote.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconTextQuote

--- a/components/Icons/IconUIAlert.jsx
+++ b/components/Icons/IconUIAlert.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIAlert = (props) => {
   const fill = props.fill || '#62AADC'
@@ -16,10 +17,10 @@ const IconUIAlert = (props) => {
 }
 
 IconUIAlert.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIAlert

--- a/components/Icons/IconUIAttach.jsx
+++ b/components/Icons/IconUIAttach.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIAttach = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIAttach = (props) => {
 }
 
 IconUIAttach.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIAttach

--- a/components/Icons/IconUIBoldAdd.jsx
+++ b/components/Icons/IconUIBoldAdd.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIBoldAdd = (props) => {
   const height = props.height || '16'
@@ -13,10 +14,10 @@ const IconUIBoldAdd = (props) => {
 }
 
 IconUIBoldAdd.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIBoldAdd

--- a/components/Icons/IconUIBoldDelete.jsx
+++ b/components/Icons/IconUIBoldDelete.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIBoldDelete = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIBoldDelete = (props) => {
 }
 
 IconUIBoldDelete.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIBoldDelete

--- a/components/Icons/IconUIBoldRemove.jsx
+++ b/components/Icons/IconUIBoldRemove.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIBoldRemove = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIBoldRemove = (props) => {
 }
 
 IconUIBoldRemove.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIBoldRemove

--- a/components/Icons/IconUICalendarAdd.jsx
+++ b/components/Icons/IconUICalendarAdd.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUICalendarAdd = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUICalendarAdd = (props) => {
 }
 
 IconUICalendarAdd.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUICalendarAdd

--- a/components/Icons/IconUIChat.jsx
+++ b/components/Icons/IconUIChat.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIChat = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIChat = (props) => {
 }
 
 IconUIChat.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIChat

--- a/components/Icons/IconUICheckBold.jsx
+++ b/components/Icons/IconUICheckBold.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUICheckBold = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUICheckBold = (props) => {
 }
 
 IconUICheckBold.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUICheckBold

--- a/components/Icons/IconUICheckSimple.jsx
+++ b/components/Icons/IconUICheckSimple.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUICheckSimple = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,11 +15,11 @@ const IconUICheckSimple = (props) => {
 }
 
 IconUICheckSimple.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number,
-  wrapperClass: React.PropTypes.string
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number,
+  wrapperClass: PropTypes.string
 }
 
 export default IconUICheckSimple

--- a/components/Icons/IconUIGrid.jsx
+++ b/components/Icons/IconUIGrid.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIGrid = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIGrid = (props) => {
 }
 
 IconUIGrid.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIGrid

--- a/components/Icons/IconUIHelp.jsx
+++ b/components/Icons/IconUIHelp.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIHelp = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIHelp = (props) => {
 }
 
 IconUIHelp.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIHelp

--- a/components/Icons/IconUIInfo.jsx
+++ b/components/Icons/IconUIInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIInfo = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIInfo = (props) => {
 }
 
 IconUIInfo.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIInfo

--- a/components/Icons/IconUILink.jsx
+++ b/components/Icons/IconUILink.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUILink = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUILink = (props) => {
 }
 
 IconUILink.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUILink

--- a/components/Icons/IconUIPencil.jsx
+++ b/components/Icons/IconUIPencil.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIPencil = (props) => {
   const height = props.height || '16'
@@ -13,10 +14,10 @@ const IconUIPencil = (props) => {
 }
 
 IconUIPencil.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIPencil

--- a/components/Icons/IconUISettingsGear.jsx
+++ b/components/Icons/IconUISettingsGear.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUISettingsGear = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUISettingsGear = (props) => {
 }
 
 IconUISettingsGear.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUISettingsGear

--- a/components/Icons/IconUITrashSimple.jsx
+++ b/components/Icons/IconUITrashSimple.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUITrashSimple = (props) => {
   const height = props.height || '16'
@@ -13,10 +14,10 @@ const IconUITrashSimple = (props) => {
 }
 
 IconUITrashSimple.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUITrashSimple

--- a/components/Icons/IconUIZoom.jsx
+++ b/components/Icons/IconUIZoom.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUIZoom = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUIZoom = (props) => {
 }
 
 IconUIZoom.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUIZoom

--- a/components/Icons/IconUsersAdd.jsx
+++ b/components/Icons/IconUsersAdd.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUsersAdd = (props) => {
   const fill = props.fill || '#62AADC'
@@ -14,10 +15,10 @@ const IconUsersAdd = (props) => {
 }
 
 IconUsersAdd.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUsersAdd

--- a/components/Icons/IconUsersDelete.jsx
+++ b/components/Icons/IconUsersDelete.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUsersDelete = (props) => {
   const fill = props.fill || '#262628'
@@ -15,10 +16,10 @@ const IconUsersDelete = (props) => {
 }
 
 IconUsersDelete.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUsersDelete

--- a/components/Icons/IconUsersMultiple.jsx
+++ b/components/Icons/IconUsersMultiple.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUsersMultiple = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconUsersMultiple = (props) => {
 }
 
 IconUsersMultiple.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUsersMultiple

--- a/components/Icons/IconUsersSingle.jsx
+++ b/components/Icons/IconUsersSingle.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconUsersSingle = (props) => {
   const fill = props.fill || '#62AADC'
@@ -15,10 +16,10 @@ const IconUsersSingle = (props) => {
 }
 
 IconUsersSingle.propTypes = {
-  fill   : React.PropTypes.string,
-  stroke : React.PropTypes.string,
-  height : React.PropTypes.number,
-  width  : React.PropTypes.number
+  fill   : PropTypes.string,
+  stroke : PropTypes.string,
+  height : PropTypes.number,
+  width  : PropTypes.number
 }
 
 export default IconUsersSingle

--- a/components/Icons/social-media/IconSocialDribbble.jsx
+++ b/components/Icons/social-media/IconSocialDribbble.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialDribbble = (props) => {
   const height = props.height || '48'
@@ -13,8 +14,8 @@ const IconSocialDribbble = (props) => {
 }
 
 IconSocialDribbble.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialDribbble

--- a/components/Icons/social-media/IconSocialDropbox.jsx
+++ b/components/Icons/social-media/IconSocialDropbox.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialDropbox = (props) => {
   const height = props.height || '48'
@@ -15,8 +16,8 @@ const IconSocialDropbox = (props) => {
 }
 
 IconSocialDropbox.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialDropbox

--- a/components/Icons/social-media/IconSocialFacebook.jsx
+++ b/components/Icons/social-media/IconSocialFacebook.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialFacebook = (props) => {
   const height = props.height || '48'
@@ -13,8 +14,8 @@ const IconSocialFacebook = (props) => {
 }
 
 IconSocialFacebook.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialFacebook

--- a/components/Icons/social-media/IconSocialGithub.jsx
+++ b/components/Icons/social-media/IconSocialGithub.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialGithub = (props) => {
   const height = props.height || '48'
@@ -12,8 +13,8 @@ const IconSocialGithub = (props) => {
 }
 
 IconSocialGithub.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialGithub

--- a/components/Icons/social-media/IconSocialGooglePlus.jsx
+++ b/components/Icons/social-media/IconSocialGooglePlus.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialGooglePlus = (props) => {
   const height = props.height || '48'
@@ -12,8 +13,8 @@ const IconSocialGooglePlus = (props) => {
 }
 
 IconSocialGooglePlus.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialGooglePlus

--- a/components/Icons/social-media/IconSocialLinkedin.jsx
+++ b/components/Icons/social-media/IconSocialLinkedin.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialLinkedin = (props) => {
   const height = props.height || '48'
@@ -13,8 +14,8 @@ const IconSocialLinkedin = (props) => {
 }
 
 IconSocialLinkedin.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialLinkedin

--- a/components/Icons/social-media/IconSocialPaypal.jsx
+++ b/components/Icons/social-media/IconSocialPaypal.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialPayPal = (props) => {
   const height = props.height || '48'
@@ -14,8 +15,8 @@ const IconSocialPayPal = (props) => {
 }
 
 IconSocialPayPal.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialPayPal

--- a/components/Icons/social-media/IconSocialSlack.jsx
+++ b/components/Icons/social-media/IconSocialSlack.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialSlack = (props) => {
   const height = props.height || '48'
@@ -19,8 +20,8 @@ const IconSocialSlack = (props) => {
 }
 
 IconSocialSlack.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialSlack

--- a/components/Icons/social-media/IconSocialTrello.jsx
+++ b/components/Icons/social-media/IconSocialTrello.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialTrello = (props) => {
   const height = props.height || '48'
@@ -12,8 +13,8 @@ const IconSocialTrello = (props) => {
 }
 
 IconSocialTrello.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialTrello

--- a/components/Icons/social-media/IconSocialTwitter.jsx
+++ b/components/Icons/social-media/IconSocialTwitter.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialTwitter = (props) => {
   const height = props.height || '48'
@@ -12,8 +13,8 @@ const IconSocialTwitter = (props) => {
 }
 
 IconSocialTwitter.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialTwitter

--- a/components/Icons/social-media/IconSocialYoutube.jsx
+++ b/components/Icons/social-media/IconSocialYoutube.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconSocialYouTube = (props) => {
   const height = props.height || '48'
@@ -13,8 +14,8 @@ const IconSocialYouTube = (props) => {
 }
 
 IconSocialYouTube.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default IconSocialYouTube

--- a/components/ImageViewer/ImageViewerContainer.coffee
+++ b/components/ImageViewer/ImageViewerContainer.coffee
@@ -1,26 +1,29 @@
 'use strict'
 
 React = require 'react'
-{ PropTypes, createElement, createClass } = React
+{ PropTypes, createElement } = React
 ImageViewerElement = require './ImageViewer.cjsx'
 
-ImageViewer = React.createClass
-  propTypes:
+class ImageViewer extends React.Component
+  @propTypes =
     files: PropTypes.array.isRequired
     showNotifications: PropTypes.bool
     initialFile: PropTypes.object.isRequired
     onFileChange: PropTypes.func
 
-  getInitialState: ->
-    file = this.props.initialFile
-    currentIndex = this.props.files.indexOf this.props.initialFile
-    nextFile = currentIndex + 1 < this.props.files.length
-    prevFile = currentIndex - 1 >= 0
-
-    file: file
-    currentIndex: currentIndex
-    nextFile: nextFile
-    prevFile: prevFile
+  constructor: (props) ->
+    super(props)
+    currentIndex = props.files.indexOf props.initialFile
+    this.state =
+      file: props.initialFile
+      currentIndex: currentIndex
+      nextFile: currentIndex + 1 < props.files.length
+      prevFile: currentIndex - 1 >= 0
+    this.viewNext = this.viewNext.bind this
+    this.viewPrevious = this.viewPrevious.bind this
+    this.selectFile = this.selectFile.bind this
+    this.updateArrowsState = this.updateArrowsState.bind this
+    this.toggleZoom = this.toggleZoom.bind this
 
   componentWillMount: ->
     this.props.onFileChange({file: this.state.file}) if this.props.onFileChange

--- a/components/ImageViewer/ImageViewerContainer.coffee
+++ b/components/ImageViewer/ImageViewerContainer.coffee
@@ -1,7 +1,8 @@
 'use strict'
 
 React = require 'react'
-{ PropTypes, createElement, createClass } = React
+PropTypes = require 'prop-types'
+{ createElement, createClass } = React
 ImageViewerElement = require './ImageViewer.cjsx'
 
 ImageViewer = React.createClass

--- a/components/LoginScreen/index.jsx
+++ b/components/LoginScreen/index.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import Formsy from 'formsy-react'
 import TextInput from '../Formsy/TextInput'
 import PasswordInput from '../Formsy/PasswordInput'

--- a/components/ManageSteps/ManageSteps.coffee
+++ b/components/ManageSteps/ManageSteps.coffee
@@ -5,8 +5,8 @@ ManageStepsView        = require './ManageStepsView'
 { connect }            = require 'react-redux'
 { loadStepsByProject } = require 'appirio-tech-client-app-layer'
 
-ManageSteps = React.createClass
-  propTypes:
+class ManageSteps extends React.Component
+  @propTypes =
     projectId: React.PropTypes.string.isRequired
     permissions: React.PropTypes.array
 

--- a/components/ManageSteps/ManageSteps.coffee
+++ b/components/ManageSteps/ManageSteps.coffee
@@ -1,14 +1,15 @@
 'use strict'
 
 React                  = require 'react'
+PropTypes              = require 'prop-types'
 ManageStepsView        = require './ManageStepsView'
 { connect }            = require 'react-redux'
 { loadStepsByProject } = require 'appirio-tech-client-app-layer'
 
 ManageSteps = React.createClass
   propTypes:
-    projectId: React.PropTypes.string.isRequired
-    permissions: React.PropTypes.array
+    projectId: PropTypes.string.isRequired
+    permissions: PropTypes.array
 
   componentWillMount: ->
     { loadStepsByProject, projectId } = this.props

--- a/components/ManageSteps/ManageStepsView.cjsx
+++ b/components/ManageSteps/ManageStepsView.cjsx
@@ -3,6 +3,7 @@
 require './ManageSteps.scss'
 
 React      = require 'react'
+PropTypes  = require 'prop-types'
 classNames = require 'classnames'
 StepRow    = require '../StepRow/StepRow.coffee'
 
@@ -59,9 +60,9 @@ component = ({projectId, stepIds, fetching, permissions}) ->
   </div>
 
 component.propTypes =
-  projectId: React.PropTypes.string.isRequired
-  stepIds: React.PropTypes.array.isRequired
-  permissions: React.PropTypes.array.isRequired
-  fetching: React.PropTypes.bool
+  projectId: PropTypes.string.isRequired
+  stepIds: PropTypes.array.isRequired
+  permissions: PropTypes.array.isRequired
+  fetching: PropTypes.bool
 
 module.exports = component

--- a/components/MenuBar/MenuBar.jsx
+++ b/components/MenuBar/MenuBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import classNames from 'classnames'
 import NavLink from '../NavLink/NavLink'

--- a/components/NavLink/NavLink.jsx
+++ b/components/NavLink/NavLink.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { NavLink as RNavLink, matchPath} from 'react-router-dom'
 
 class NavLink extends Component {

--- a/components/Navbar/Navbar.jsx
+++ b/components/Navbar/Navbar.jsx
@@ -1,6 +1,7 @@
 require('./Navbar.scss')
 
-import React, {PropTypes, Component} from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import MenuBar from '../MenuBar/MenuBar'
 import SearchBar from '../SearchBar/SearchBar'
 import QuickLinks from '../QuickLinks/QuickLinks'

--- a/components/Navbar/NavbarExample.jsx
+++ b/components/Navbar/NavbarExample.jsx
@@ -1,7 +1,8 @@
 require('./NavbarExample.scss')
 
 import Navbar from './Navbar'
-import React, {Component, PropTypes} from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import fetch from 'isomorphic-fetch'
 import _ from 'lodash'
 

--- a/components/Panel/Panel.jsx
+++ b/components/Panel/Panel.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 require('./Panel.scss')
 

--- a/components/Prize/PrizeItems.jsx
+++ b/components/Prize/PrizeItems.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import TaggedValueList from '../TaggedValue/TaggedValueList'
 
@@ -21,8 +22,8 @@ const PrizeItems = ({type, title, items}) => {
 }
 
 PrizeItems.propTypes = {
-  type :  React.PropTypes.string,
-  items :  React.PropTypes.array
+  type :  PropTypes.string,
+  items :  PropTypes.array
 }
 
 export default PrizeItems

--- a/components/ProgressBar/ProgressBar.jsx
+++ b/components/ProgressBar/ProgressBar.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 require('./ProgressBar.scss')
@@ -68,8 +69,8 @@ const ProgressBar = ({completionPercentage, checkPoints}) => {
 }
 
 ProgressBar.propTypes = {
-  completionPercentage :  React.PropTypes.string,
-  checkPoints :  React.PropTypes.array
+  completionPercentage :  PropTypes.string,
+  checkPoints :  PropTypes.array
 }
 
 export default ProgressBar

--- a/components/SearchBar/SearchBar.jsx
+++ b/components/SearchBar/SearchBar.jsx
@@ -1,6 +1,7 @@
 require('./SearchBar.scss')
 
-import React, {Component, PropTypes} from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import SearchSuggestions from '../SearchSuggestions/SearchSuggestions'
 import Loader from '../Loader/Loader'

--- a/components/SearchSuggestions/SearchSuggestions.jsx
+++ b/components/SearchSuggestions/SearchSuggestions.jsx
@@ -1,6 +1,7 @@
 require('./SearchSuggestions.scss')
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import StandardListItem from '../StandardListItem/StandardListItem'
 import Panel from '../Panel/Panel'
 import classNames from 'classnames'

--- a/components/SelectDropdown/SelectDropdown.jsx
+++ b/components/SelectDropdown/SelectDropdown.jsx
@@ -1,7 +1,8 @@
 require('./SelectDropdown.scss')
 
 import _ from 'lodash'
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import Dropdown from '../Dropdown/Dropdown'
 
 class SelectDropdown extends Component {
@@ -44,7 +45,7 @@ class SelectDropdown extends Component {
 
 SelectDropdown.propTypes = {
   onSelect : PropTypes.func,
-  options  : PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  options  : PropTypes.arrayOf(PropTypes.object).isRequired,
   theme    : PropTypes.string
 }
 

--- a/components/StandardListItem/StandardListItem.jsx
+++ b/components/StandardListItem/StandardListItem.jsx
@@ -1,5 +1,5 @@
-import {PropTypes } from 'react'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 require('./StandardListItemStyles.scss')
  // showIcon: true -> render the icon

--- a/components/StepRow/StatusSelect.cjsx
+++ b/components/StepRow/StatusSelect.cjsx
@@ -3,7 +3,7 @@
 require 'react-select/dist/react-select.css'
 
 React      = require 'react'
-PropTypes  = React.PropTypes
+PropTypes  = require 'prop-types'
 Select     = require 'react-select'
 find       = require 'lodash/find'
 

--- a/components/StepRow/StepRow.coffee
+++ b/components/StepRow/StepRow.coffee
@@ -17,8 +17,8 @@ fields = [
   'status'
 ]
 
-StepRow = React.createClass
-  propTypes:
+class StepRow extends React.Component
+  @propTypes =
     fields       : PropTypes.object.isRequired
     permissions  : PropTypes.array.isRequired
     handleSubmit : PropTypes.func.isRequired
@@ -26,6 +26,10 @@ StepRow = React.createClass
     projectId    : PropTypes.string.isRequired
     stepId       : PropTypes.string
     isNew        : PropTypes.bool
+
+  constructor: (props) ->
+    super(props)
+    this.submit = this.submit.bind this
 
   componentWillMount: ->
     { loadStep, projectId, stepId } = this.props

--- a/components/StepRow/StepRow.coffee
+++ b/components/StepRow/StepRow.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 React                  = require 'react'
-PropTypes              = React.PropTypes
+PropTypes              = require 'prop-types'
 StepRowView            = require './StepRowView'
 { reduxForm }          = require 'redux-form'
 { loadStep,

--- a/components/StepRow/StepRowView.cjsx
+++ b/components/StepRow/StepRowView.cjsx
@@ -4,7 +4,7 @@ require './StepRow.scss'
 require 'react-datetime/css/react-datetime.css'
 
 React          = require 'react'
-PropTypes      = React.PropTypes
+PropTypes      = require 'prop-types'
 DateTime       = require 'react-datetime'
 classNames     = require 'classnames'
 StepTypeSelect = require './StepTypeSelect'

--- a/components/StepRow/StepTypeSelect.cjsx
+++ b/components/StepRow/StepTypeSelect.cjsx
@@ -3,7 +3,7 @@
 require 'react-select/dist/react-select.css'
 
 React      = require 'react'
-PropTypes  = React.PropTypes
+PropTypes  = require 'prop-types'
 Select     = require 'react-select'
 find       = require 'lodash/find'
 

--- a/components/SubTrackDetails/SubTrackDetails.jsx
+++ b/components/SubTrackDetails/SubTrackDetails.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 require('./SubTrackDetails.scss')
@@ -31,10 +32,10 @@ const SubTrackDetails = ({name, code, description, tracks}) => {
 }
 
 SubTrackDetails.propTypes = {
-  name: React.PropTypes.string,
-  code: React.PropTypes.string,
-  description: React.PropTypes.string,
-  tracks: React.PropTypes.array
+  name: PropTypes.string,
+  code: PropTypes.string,
+  description: PropTypes.string,
+  tracks: PropTypes.array
 }
 
 export default SubTrackDetails

--- a/components/Tabs/Tab.jsx
+++ b/components/Tabs/Tab.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const Tab = ({children}) => <div>{children}</div>
 

--- a/components/Tabs/Tabs.jsx
+++ b/components/Tabs/Tabs.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import uncontrollable from 'uncontrollable'
 import cn from 'classnames'
 require('./Tabs.scss')
@@ -29,7 +30,7 @@ Tabs.propTypes = {
   /**
    * Mark the Tab with a matching `eventKey` as active.
    */
-  activeKey: React.PropTypes.any,
+  activeKey: PropTypes.any,
 
   /**
    * Callback fired when a Tab is selected.
@@ -41,7 +42,7 @@ Tabs.propTypes = {
    * )
    *
    */
-  onSelect: React.PropTypes.func
+  onSelect: PropTypes.func
 }
 
 

--- a/components/TaggedValue/TaggedValue.jsx
+++ b/components/TaggedValue/TaggedValue.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 require('./TaggedValue.scss')
@@ -21,10 +22,10 @@ const TaggedValue = ({title, subText, style, count}) => {
 }
 
 TaggedValue.propTypes = {
-  title :  React.PropTypes.string,
-  subText :  React.PropTypes.string,
-  style : React.PropTypes.string,
-  count : React.PropTypes.string
+  title :  PropTypes.string,
+  subText :  PropTypes.string,
+  style : PropTypes.string,
+  count : PropTypes.string
 }
 
 export default TaggedValue

--- a/components/TaggedValue/TaggedValueList.jsx
+++ b/components/TaggedValue/TaggedValueList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import TaggedValue from './TaggedValue'
 import classNames from 'classnames'
 
@@ -21,8 +22,8 @@ const TaggedValueList = ({items, layout}) => {
 }
 
 TaggedValueList.propTypes = {
-  items :  React.PropTypes.array,
-  layout : React.PropTypes.oneOf(['scroll', 'wrap'])
+  items :  PropTypes.array,
+  layout : PropTypes.oneOf(['scroll', 'wrap'])
 }
 
 export default TaggedValueList

--- a/components/Tooltip/Tooltip.jsx
+++ b/components/Tooltip/Tooltip.jsx
@@ -1,7 +1,8 @@
 /**
  * Tooltip
  */
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import { Manager, Target, Popper, Arrow } from 'react-popper'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'

--- a/components/UploadedFiles/UploadedFilesContainer.cjsx
+++ b/components/UploadedFiles/UploadedFilesContainer.cjsx
@@ -1,13 +1,14 @@
 'use strict'
 
 React         = require 'react'
+PropTypes      = require 'prop-types'
 { connect }   = require 'react-redux'
 classnames    = require 'classnames'
 UploadedFiles = require './UploadedFiles'
 
 { getAttachments, deleteAttachment } = require 'appirio-tech-client-app-layer'
 
-{ createClass, createElement, PropTypes } = React
+{ createClass, createElement } = React
 
 mapStateToProps = (state) ->
   { id, assetType, category, enableCaptions } = state?.fileUploader

--- a/components/UploadedFiles/UploadedFilesContainer.cjsx
+++ b/components/UploadedFiles/UploadedFilesContainer.cjsx
@@ -7,7 +7,7 @@ UploadedFiles = require './UploadedFiles'
 
 { getAttachments, deleteAttachment } = require 'appirio-tech-client-app-layer'
 
-{ createClass, createElement, PropTypes } = React
+{ createElement, PropTypes } = React
 
 mapStateToProps = (state) ->
   { id, assetType, category, enableCaptions } = state?.fileUploader
@@ -27,8 +27,8 @@ mapStateToProps = (state) ->
 
   { id, assetType, category, files }
 
-container =
-  propTypes:
+class UploadedFilesContainer extends React.Component
+  @propTypes =
     id            : PropTypes.string.isRequired
     assetType     : PropTypes.string.isRequired
     category      : PropTypes.string.isRequired
@@ -36,6 +36,10 @@ container =
     files         : PropTypes.array.isRequired
     enableCaptions: PropTypes.bool
     disabled      : PropTypes.bool
+
+  constructor: (props) ->
+    super(props)
+    this.onDelete = this.onDelete.bind this
 
   onDelete: (file) ->
     this.props.dispatch deleteAttachment file
@@ -54,5 +58,5 @@ container =
       enableCaptions: enableCaptions
       disabled      : disabled
 
-module.exports = connect(mapStateToProps)(createClass(container))
+module.exports = connect(mapStateToProps)(UploadedFilesContainer)
 

--- a/components/UserDropdownMenu/UserDropdownMenu.jsx
+++ b/components/UserDropdownMenu/UserDropdownMenu.jsx
@@ -1,6 +1,7 @@
 require('./UserDropdownMenu.scss')
 
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Link } from 'react-router-dom'
 import Avatar from '../Avatar/Avatar'

--- a/components/Wizard/Wizard.jsx
+++ b/components/Wizard/Wizard.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import WizardTop from './WizardTop'
 import WizardLeft from './WizardLeft'
 import WizardRight from './WizardRight'

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "libphonenumber-js": "^1.4.6",
     "lodash": "^4.0.0",
     "moment": "^2.11.2",
+    "prop-types": "^15.7.2",
     "react": "^15.3.1",
     "react-addons-pure-render-mixin": "^15.3.1",
     "react-addons-update": "^15.3.1",


### PR DESCRIPTION
This is the first step to migrating to React 16.
Get rid of two deprecated methods inside `react-components`:
- use `PropTypes` from `react-props` instead of `react`
- don't use `createClass` method in favor of ES2015 classes

This PR is compatible with React 15 and don't have any breaking changes. It would be good to merge it so the new code we add before migrating to React 16 follows the requirement to no use deprecated methods.